### PR TITLE
Fail releases on registry errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Publish cortex-memory-proto
-        run: cargo publish -p cortex-memory-proto --allow-dirty || echo "Already published"
+        run: cargo publish -p cortex-memory-proto --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -180,7 +180,7 @@ jobs:
         run: sleep 30
 
       - name: Publish cortex-memory-core
-        run: cargo publish -p cortex-memory-core --no-default-features --allow-dirty || echo "Already published"
+        run: cargo publish -p cortex-memory-core --no-default-features --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -188,7 +188,7 @@ jobs:
         run: sleep 30
 
       - name: Publish cortex-memory-client
-        run: cargo publish -p cortex-memory-client --allow-dirty || echo "Already published"
+        run: cargo publish -p cortex-memory-client --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -196,7 +196,7 @@ jobs:
         run: sleep 30
 
       - name: Publish cortex-memory (binary)
-        run: cargo publish -p cortex-memory --no-default-features --allow-dirty || echo "Already published"
+        run: cargo publish -p cortex-memory --no-default-features --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/mcp-bridge/package.json
+++ b/mcp-bridge/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "description": "Node.js MCP bridge for a local or remote Cortex graph-memory server",
   "bin": {
-    "cortex-mcp-bridge": "./cortex-mcp-bridge.js"
+    "cortex-mcp-bridge": "cortex-mcp-bridge.js"
   },
   "scripts": {
     "test": "node --test test.mjs"


### PR DESCRIPTION
Stops crates.io authentication failures being reported as successful and normalizes the MCP bridge bin path so npm preserves the executable.\n\nValidation: MCP bridge test and npm pack dry-run pass; release workflow YAML parses successfully.